### PR TITLE
Added back config example. Renamed section keys for consistency with core MultiQC

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,33 @@ For more information about BaseSpace Clarity LIMS, see https://www.genologics.co
 
 ## Installation
 
-## Usage
-
 ## Configuration
+Before MultiQC_Clarity will work with MultiQC, you need to tell it what information
+to retrieve from the LIMS. Unfortunately, as every Clarity installation is different
+from the next, this cannot be automated.
+
+To do this, you need to add to your MultiQC configuration. See the
+[main MultiQC documentation](http://multiqc.info/docs/#configuring-multiqc)
+for more information on how to do this. For a single run, you can just create
+a file called `multiqc_config.yaml` in the working directory.
+
+MultiQC clarity expects a config structure that looks something like this:
+
+```yaml
+clarity:
+    <report section>:
+        <process>:
+            '<udf>':
+```
+
+See the bundled [`multiqc_config_example.yaml`](multiqc_config_example.yaml)
+file to see a real-life example of this.
+
+One special config param not usually available is `multiply_by`.
+For example, to display a count in for Millions, set `multiply_by: 0.000001`.
+To display a fraction as a percent, set `multiply_by: 100`.
+
+## Usage
 
 ### Contributors
 MultiQC_Clarity lead and main author: [@Galithil](https://github.com/Galithil)

--- a/multiqc_clarity/multiqc_clarity.py
+++ b/multiqc_clarity/multiqc_clarity.py
@@ -40,9 +40,9 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             return None
 
         self.get_samples()
-        self.get_metadata('Header')
-        self.get_metadata('General Statistics')
-        self.get_metadata('Clarity Tab')
+        self.get_metadata('report_header_info')
+        self.get_metadata('general_stats')
+        self.get_metadata('clarity_module')
         self.update_multiqc_report()
         self.make_sections()
         report.modules_output.append(self)
@@ -141,9 +141,9 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             else:
                 metadata = self.get_artifact_metadata(self.schema[part])
 
-            if part == "Header":
+            if part == "report_header_info":
                 self.header_metadata.update(metadata)
-            elif part == "General Statistics":
+            elif part == "general_stats":
                 self.general_metadata.update(metadata)
             else:
                 self.tab_metadata.update(metadata)
@@ -192,8 +192,8 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             config.report_header_info.append(d)
 
         headers = {}
-        for first_level in self.schema["General Statistics"]:
-            for header in self.schema["General Statistics"][first_level]:
+        for first_level in self.schema["general_stats"]:
+            for header in self.schema["general_stats"][first_level]:
                 headers[header]= {'description': first_level,
                                                'namespace': 'Clarity',
                                                'scale': 'YlGn'}
@@ -207,12 +207,12 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             for header in self.tab_metadata[first_level]:
                 desc = header
                 if header not in headers:
-                    for key in self.schema['Clarity Tab']:
-                        if header in self.schema['Clarity Tab'][key]:
+                    for key in self.schema['clarity_module']:
+                        if header in self.schema['clarity_module'][key]:
                             desc = key
-                        elif isinstance(self.schema['Clarity Tab'][key], dict):
-                            for subkey in self.schema['Clarity Tab'][key]:
-                                if header in self.schema['Clarity Tab'][key][subkey]:
+                        elif isinstance(self.schema['clarity_module'][key], dict):
+                            for subkey in self.schema['clarity_module'][key]:
+                                if header in self.schema['clarity_module'][key][subkey]:
                                     desc = key
 
                     headers[header] = {

--- a/multiqc_config_example.yaml
+++ b/multiqc_config_example.yaml
@@ -1,0 +1,28 @@
+'clarity':
+    'report_header_info':
+        'Project':
+            - 'Sequencing platform'
+            - 'Order received'
+
+    'general_stats':
+        'Sample':
+            - 'Customer Name'
+            - 'Customer Conc'
+
+
+    'clarity_module':
+        'Sample':
+            - 'Customer Name'
+            - 'Customer Conc'
+
+        'Aggregate QC (Library Validation) 4.0':
+            inputs:
+                - 'Concentration'
+                - 'Size (bp)'
+                - 'Volume (ul)'
+
+        'Bcl Conversion & Demultiplexing (Illumina SBS) 4.0':
+            outputs:
+                - '# Reads'
+                - '% Bases >=Q30'
+

--- a/multiqc_config_example.yaml
+++ b/multiqc_config_example.yaml
@@ -1,28 +1,37 @@
-'clarity':
-    'report_header_info':
-        'Project':
-            - 'Sequencing platform'
-            - 'Order received'
+clarity:
+    report_header_info:
+        Project:
+            'Sequencing platform':
+            'Order received':
 
-    'general_stats':
-        'Sample':
-            - 'Customer Name'
-            - 'Customer Conc'
+    general_stats:
+        Sample:
+            'Customer Name':
+                scale: False
+            'Customer Conc':
+                description: 'Customer Concentration (&micro;g/&micro;l)'
 
 
-    'clarity_module':
-        'Sample':
-            - 'Customer Name'
-            - 'Customer Conc'
+    clarity_module:
+        Sample:
+            'Customer Name':
+            'Customer Conc':
 
         'Aggregate QC (Library Validation) 4.0':
             inputs:
-                - 'Concentration'
-                - 'Size (bp)'
-                - 'Volume (ul)'
+                'Concentration':
+                'Size (bp)':
+                'Volume (ul)':
 
         'Bcl Conversion & Demultiplexing (Illumina SBS) 4.0':
             outputs:
-                - '# Reads'
-                - '% Bases >=Q30'
+                '# Reads':
+                    'namespace': 'Demultiplexing'
+                    'title': 'M Reads'
+                    'description': 'Million Reads Sequenced'
+                    'format': '{:.2f}'
+                    'multiply_by': 0.000001
+                '% Bases >=Q30':
+                    'namespace': 'Demultiplexing'
+                    'scale': 'RdYlGn'
 


### PR DESCRIPTION
Sorry, pedantic stuff, I just thought it would be clearer if the config sections shared similar names to those used to describe report sections elsewhere.

Config file went missing when I renamed it before, as `multiqc_config.yaml` is in the `.gitignore` I added earlier. Will now need `-c multiqc_config_example.yaml` to run, as no longer a default config filename.