### PR TITLE
Allow name editing with regex

### DIFF
--- a/multiqc_clarity/cli.py
+++ b/multiqc_clarity/cli.py
@@ -18,8 +18,3 @@ c_edit_patterns = click.option('--clarity_skip_name_editing',
     default = False,
     help = "Do not edit the sample names to remove suffixes like _1, _2, _R1, _R2."
 )
-c_edit_name_with_regex = click.option('--clarity_name_edit_from_config',
-    is_flag = True,
-    default = False,
-    help = "Edit sample names using regex specified in config."
-)

--- a/multiqc_clarity/cli.py
+++ b/multiqc_clarity/cli.py
@@ -18,3 +18,8 @@ c_edit_patterns = click.option('--clarity_skip_name_editing',
     default = False,
     help = "Do not edit the sample names to remove suffixes like _1, _2, _R1, _R2."
 )
+c_edit_name_with_regex = click.option('--clarity_name_edit_from_config',
+    is_flag = True,
+    default = False,
+    help = "Edit sample names using regex specified in config."
+)

--- a/multiqc_clarity/multiqc_clarity.py
+++ b/multiqc_clarity/multiqc_clarity.py
@@ -41,10 +41,7 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             self.log.debug("No config found for MultiQC_Clarity")
             return None
 
-        if self.schema.get("name_edit_regex"):
-            self.name_edit_regex = self.schema.get("name_edit_regex")
-        else:
-            self.name_edit_regex = None
+        self.name_edit_regex = self.schema.get("name_edit_regex")
 
         self.get_samples()
         self.get_metadata('report_header_info')

--- a/multiqc_clarity/multiqc_clarity.py
+++ b/multiqc_clarity/multiqc_clarity.py
@@ -53,9 +53,14 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
 
 
     def get_samples(self):
-        if config.kwargs.get('clarity_project_name'):
-            pj = self.lims.get_projects(name=config.kwargs['clarity_project_name'])
-            self.samples = pj.samples
+        if config.kwargs.get('clarity_project'):
+            pj = self.lims.get_projects(name=config.kwargs['clarity_project'])
+            if len(pj) > 1:
+                self.log.error("Found multiple match projects in Clarity.")
+            elif len(pj) < 1:
+                self.log.error("Could not identify project in Clarity.")
+            else:
+                self.samples = self.lims.get_samples(projectlimsid=pj[0].id)
         else:
             names = set()
             for x in report.general_stats_data:
@@ -68,7 +73,7 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             if not config.kwargs.get('clarity_skip_edit_names'):
                 names = self.edit_names(names)
 
-            self.log.debug("Looking into Clarity for samples {}".format(", ".join(names)))
+            self.log.info("Looking into Clarity for samples {}".format(", ".join(names)))
             found = 0
             try:
                 for name in names:
@@ -84,7 +89,7 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             except Exception as e:
                 self.log.warn("Could not connect to Clarity LIMS: {}".format(e))
                 return None
-        self.log.info("Found {} out of {} samples in LIMS.".format(found, len(names)))
+            self.log.info("Found {} out of {} samples in LIMS.".format(found, len(names)))
 
 
     def edit_names(self, names):

--- a/multiqc_clarity/multiqc_clarity.py
+++ b/multiqc_clarity/multiqc_clarity.py
@@ -34,7 +34,6 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
         self.header_metadata = {}
         self.general_metadata = {}
         self.tab_metadata = {}
-        self.name_edit_regex = None
         self.samples = []
 
         self.schema = getattr(config, 'clarity', None)
@@ -42,7 +41,11 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
             self.log.debug("No config found for MultiQC_Clarity")
             return None
 
-        self.get_metadata('name_edit_regex')
+        if self.schema.get("name_edit_regex"):
+            self.name_edit_regex = self.schema.get("name_edit_regex")
+        else:
+            self.name_edit_regex = None
+
         self.get_samples()
         self.get_metadata('report_header_info')
         self.get_metadata('general_stats')
@@ -93,7 +96,7 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
 
 
     def edit_names(self, names):
-        if config.kwargs.get('clarity_name_edit_from_config'):
+        if self.name_edit_regex:
             return self.edit_names_with_regex(names)
 
         edited=[]
@@ -164,8 +167,6 @@ class MultiQC_clarity_metadata(BaseMultiqcModule):
                 self.header_metadata.update(metadata)
             elif part == "general_stats":
                 self.general_metadata.update(metadata)
-            elif part == "name_edit_regex":
-                self.name_edit_regex = self.schema[part]
             else:
                 self.tab_metadata.update(metadata)
 

--- a/multiqc_config_example.yaml
+++ b/multiqc_config_example.yaml
@@ -1,4 +1,6 @@
 clarity:
+    name_edit_regex: '^(.*)_L\d{3}_R\d_001$'
+
     report_header_info:
         Project:
             'Sequencing platform':

--- a/multiqc_config_example.yaml
+++ b/multiqc_config_example.yaml
@@ -1,5 +1,8 @@
 clarity:
-    name_edit_regex: '^(.*)_L\d{3}_R\d_001$'
+    # Uncomment this edit the sample names using a regex.
+    # It is assumed that the first match group contains the
+    # sample name
+    #name_edit_regex: '^(.*)_L\d{3}_R\d_001$'
 
     report_header_info:
         Project:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'multiqc.cli_options.v1': [
                         'disable_clarity = multiqc_clarity.cli:c_disable',
                         'clarity_skip_edit_snames = multiqc_clarity.cli:c_edit_patterns',
-                        'clarity_project_name = multiqc_clarity.cli:c_pname'
+                        'clarity_project_name = multiqc_clarity.cli:c_pname',
+                        'clarity_name_edit_from_config = multiqc_clarity.cli:c_edit_name_with_regex'
                         ]
     },
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'multiqc.cli_options.v1': [
                         'disable_clarity = multiqc_clarity.cli:c_disable',
                         'clarity_skip_edit_snames = multiqc_clarity.cli:c_edit_patterns',
-                        'clarity_project_name = multiqc_clarity.cli:c_pname'
+                        'clarity_project = multiqc_clarity.cli:c_pname'
                         ]
     },
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,7 @@ setup(
         'multiqc.cli_options.v1': [
                         'disable_clarity = multiqc_clarity.cli:c_disable',
                         'clarity_skip_edit_snames = multiqc_clarity.cli:c_edit_patterns',
-                        'clarity_project_name = multiqc_clarity.cli:c_pname',
-                        'clarity_name_edit_from_config = multiqc_clarity.cli:c_edit_name_with_regex'
+                        'clarity_project_name = multiqc_clarity.cli:c_pname'
                         ]
     },
     classifiers = [


### PR DESCRIPTION
We will perhaps start using the plug-in at the SNP&SEQ Technology Platform. Looking into this I noticed that the sample naming conventions assumed here do not match the once we use, so I've added an option to use a regular expression to gather the sample name.

Furthermore in the process of working on this I found what I think is a bug in the way that samples are gathered from Clarity if the project is specified on the command line. I might be missing something here, but using the method from https://github.com/MultiQC/MultiQC_Clarity/commit/1bf15ce7e3e339ab613ff9012605e72032bc4917 it seemed to work better for me.